### PR TITLE
fixed duplicate column glitch

### DIFF
--- a/models/staging/sources/base_hits.sql
+++ b/models/staging/sources/base_hits.sql
@@ -1,5 +1,0 @@
-WITH base_hits AS (
-    SELECT * FROM {{ ref('base_sessions') }}, UNNEST(hits) as hit
-)
-
-SELECT * FROM base_hits

--- a/models/staging/stg_hits.sql
+++ b/models/staging/stg_hits.sql
@@ -31,7 +31,7 @@ WITH stg_hits AS (
     src_hits.eventInfo.eventLabel AS event_label,
     clientId AS cid
 
-    FROM {{ ref('base_hits')}}
+    FROM {{ ref('base_sessions')}}, unnest(hits) AS src_hits
 )
 
 SELECT * FROM stg_hits


### PR DESCRIPTION
Fixed an issue causing duplicate columns (when instantiated) to throw errors from unnesting in GCP. Removed base hits, go from base sessions -> stg_hits